### PR TITLE
頁尾新增高雄據點（台灣人權促進會南部辦公室）

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -37,7 +37,12 @@
                 = link_to "04-2329-2370", "fax:0423292370"
               li
                 i.fas.fa-map-marker-alt
-                = link_to '40143 台中市東區雙十路一段4-33號10樓之2','https://maps.app.goo.gl/ZFJoP8HSoWKnExacA', target: '_blank' 
+                = link_to '40143 台中市東區雙十路一段4-33號10樓之2','https://maps.app.goo.gl/ZFJoP8HSoWKnExacA', target: '_blank'
+            h5 高雄據點
+            ul.list-icons
+              li
+                i.fas.fa-map-marker-alt
+                = link_to '台灣人權促進會南部辦公室 806 高雄市前鎮區西甲里一心二路157號10樓之4', 'https://maps.app.goo.gl/1BHZH3qGPiezyT5K9', target: '_blank'
           .col-sm-2.footer-content
             h5 站內連結
             ul.nav.nav-pills.nav-stacked


### PR DESCRIPTION
在台中辦公室下方新增高雄據點區塊，僅列地址、不放電話，
地址連結至 Google 地圖。